### PR TITLE
fix anchor in link

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -523,7 +523,7 @@ This has to be done before any route mapping:
 secure(keystoreFilePath, keystorePassword, truststoreFilePath, truststorePassword);
 ~~~
 
-If you need more help, check out the [FAQ](#enable-ssl).
+If you need more help, check out the [FAQ](#how-do-i-enable-sslhttps).
 
 ### ThreadPool
 


### PR DESCRIPTION
The updated link will still only bring the reader to the FAQ section, not to the SSL question in there specifically. But this is still better than a link which does not work at all.