### PR TITLE
Avoid using `compile` configuration for Gradle

### DIFF
--- a/_includes/macros/mavenDep.md
+++ b/_includes/macros/mavenDep.md
@@ -20,8 +20,8 @@
 ### Other dependency managers:
 <div class="smaller-code" markdown="1">
 ~~~java
-Gradle : compile "com.sparkjava:spark-core:2.9.2" // add to build.gradle (for Java users)
-Gradle : compile "com.sparkjava:spark-kotlin:1.0.0-alpha" // add to build.gradle (for Kotlin users)
+Gradle : implementation 'com.sparkjava:spark-core:2.9.2' // add to build.gradle (for Java users)
+Gradle : implementation 'com.sparkjava:spark-kotlin:1.0.0-alpha' // add to build.gradle (for Kotlin users)
    Ivy : <dependency org="com.sparkjava" name="spark-core" rev="2.9.2" conf="build" /> // ivy.xml
    SBT : libraryDependencies += "com.sparkjava" % "spark-core" % "2.9.2" // build.sbt
 ~~~


### PR DESCRIPTION
The existing suggestion for using `compile` dependencies has been discouraged with Gradle 3.4 way way back.

> `>` instead of `compile`, you should use one of `implementation` or `api`
> [The Java Library plugin (Gradle 3.4 Release Notes)](https://docs.gradle.org/3.4/release-notes.html#the-java-library-plugin)

On a recent Gradle version you will see a scary deprecation warning.

> Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.

Upon turning on `--warning-mode all` you will discover it is exactly about that `compile` declaration that is suggested.

> The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0.

This PR simply swaps the `compile` out for an `implementation`.

[The Java Library plugin configurations (The Java Library Plugin - Gradle 6.6 User Manual)](https://docs.gradle.org/6.6/userguide/java_library_plugin.html#sec:java_library_configurations_graph)